### PR TITLE
fix: windows line endings on linux files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh  text eol=lf


### PR DESCRIPTION
Forces LF line endings on .sh files as it tends to break if Win machine is setup to convert line endings